### PR TITLE
update_durable_task_example

### DIFF
--- a/lab15-durable_task-example/README.md
+++ b/lab15-durable_task-example/README.md
@@ -1,0 +1,89 @@
+# gs-core-dev-training - lab15-durable_tasks-example
+
+This lab explores GigaSpaces Durable Tasks — Distributed Tasks that can be canceled and recovered. Two use cases are covered: long-running jobs that need the ability to cancel mid-execution, and business logic tasks that run persistently in the Space and survive failover without redeployment.
+
+## Goals
+1. Understand two use cases of Durable Tasks.
+2. Learn the related Java and REST API.
+
+## What is a Durable Task?
+
+A Durable Task is a Distributed Task that can be canceled and recovered.
+
+**Use cases:**
+1. A task that does a job that takes a long time and needs the ability to cancel.
+2. Business logic - Adds the ability to change business logic of the Space without Space redeployment.
+
+* Durable Tasks extend Distributed Tasks.  
+  See: https://docs.gigaspaces.com/latest/dev-java/task-execution-overview.html DistributedTask API section
+
+* As a task, it supports the `@SupportCodeChange` annotation.
+  For business logic tasks, this annotation must be used to allow changes to task code without restarts.  
+  See: https://docs.gigaspaces.com/latest/dev-java/the-space-no-restart.html
+
+* For business logic tasks, when `isAutoStart()` returns `true` related classes will be kept in ZooKeeper to allow automatic re-execution in case of failover.  
+  **Note:** In order not to store too much data it is recommended to consider task dependencies and decide what should be dynamically loaded and what is in the common class loader.  
+  See: https://docs.gigaspaces.com/latest/dev-java/task-execution-overview.html
+
+## API Reference
+
+### GigaSpaces API
+```
+UUID registerDurableTask(DurableTask<T, R> eventTask)
+AsyncFuture executeDurable(UUID uuid)
+Set<DurableTaskInfo> listDurableTasks()
+Boolean unregisterDurableTask(UUID task)
+```
+
+`listDurableTasks` and `unregisterDurableTask` are also available in the REST API.
+
+### Durable Task Interface
+```
+interface DurableTask<T extends Serializable, R> extends DistributedTask<T, R>
+```
+`String name()` - name of the Durable Task.  
+`String description()` - describe what this task does.  
+`boolean isAutoStart()` - should be true for a business logic task and will allow automatic start upon registration and will rerun after failover.
+For a long-running task, this should be false and `execute()` should be called explicitly.  
+`boolean cancel()` - Add the logic to execute when a job terminates or is canceled.
+
+### Methods From DistributedTask
+`T execute() throws Exception` - Code that will be executed in each primary partition.  
+`R reduce(List<AsyncResult<T>> results) throws Exception` - Code that will run in the client and will gather results from all partitions and return final results.
+
+### Usage Notes
+* Durable Task extends Distributed Task and includes support for code change.
+* The `execute()` method should be implemented to instruct what to do in each partition.
+* Unlike a regular task, do not call `execute()` directly. For tasks where `isAutoStart()` returns `false`, use `executeDurable(uuid)` instead — this allows the framework to track task status and support cancellation and recovery. For tasks where `isAutoStart()` returns `true`, `execute()` is called automatically by the framework upon registration and after failover.
+
+## Build and IntelliJ Setup
+1. Change the `gigaspaces.version` in the `pom.xml`. Correct the Space name in all `main()` programs, if needed.
+2. Copy the entire `runConfigurations` folder and its contents from this project, into the `.idea` directory. You will need to restart Intellij.
+3. Make sure the `GS_LOOKUP_LOCATORS` and `GS_LOOKUP_GROUPS` environment variables are set correctly.  
+   For example, the `GS_LOOKUP_LOCATORS=localhost` and `GS_LOOKUP_GROUPS=xap-17.2.1`.
+
+   In each of the Intellij run configurations, there will be VM options that will reference these environment variables.
+
+   For example,  
+   `-Dcom.gs.jini_lus.locators=${GS_LOOKUP_LOCATORS}` and `-Dcom.gs.jini_lus.groups=${GS_LOOKUP_GROUPS}`.
+
+   Please see the main [README.md](https://github.com/GigaSpaces-ProfessionalServices/gs-core-dev-training/blob/main/README.md) for setting path values (environment variables in File | Settings | Appearance & Behavior | Path Values) used when running within Intellij.
+4. Build the project: `mvn package`
+
+## Instructions
+
+1. Start the Service Grid:  
+   Go to `$GS_HOME/bin`  
+   Run `./gs.sh host run-agent --manager --gsc-4 --restv3 --webui`
+
+   *This starts an agent, manager, 4 gscs, restv3, and the webui.*
+2. Deploy the Space. For example:
+   `./gs.sh pu deploy demo <LAB_HOME>/space/target/space.jar`
+3. From the Intellij Run Configurations, run RegisterDurableTask - This registers `EmbeddedPollingDurableTask` (with `isAutoStart=true`), which causes it to automatically start an embedded event container in each partition.
+4. Use the REST API at http://localhost:9090/api/v3/swagger-ui/index.html#/Spaces/listDurableTasks to see the list of Durable Tasks.
+5. Restart the GSC for both of the primary partitions (can be done using REST API Swagger UI).
+6. Validate `"Business Logic Task"` is still in the registered tasks list via REST API.
+7. Run DataGen to write data to the Space.
+8. See the console log - events are processed.
+9. Run CancelDurableTask - This registers and executes `CancelableCountTask`, waits `WAIT_TIME` (default 3 seconds), then unregisters it.
+10. Change `WAIT_TIME` to a longer period in `CancelDurableTask.java` and observe the REST API while the task is running and after it ends.

--- a/lab15-durable_task-example/durable/pom.xml
+++ b/lab15-durable_task-example/durable/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>durable</artifactId>
+
+    <parent>
+        <artifactId>lab15-example</artifactId>
+        <groupId>com.gigaspaces.dev.training</groupId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.gigaspaces.dev.training</groupId>
+            <artifactId>model</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/lab15-durable_task-example/durable/src/main/java/com/gs/CancelDurableTask.java
+++ b/lab15-durable_task-example/durable/src/main/java/com/gs/CancelDurableTask.java
@@ -1,0 +1,37 @@
+package com.gs;
+
+import com.gigaspaces.async.AsyncFuture;
+import org.openspaces.core.GigaSpace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.openspaces.core.GigaSpaceConfigurer;
+import org.openspaces.core.space.SpaceProxyConfigurer;
+
+import java.util.UUID;
+
+public class CancelDurableTask {
+
+    private static final Logger logger = LoggerFactory.getLogger(CancelDurableTask.class);
+    public static long WAIT_TIME = 3000;
+    public static void main(String[] args) throws Exception {
+        GigaSpace gs = new GigaSpaceConfigurer(new SpaceProxyConfigurer("demo")).gigaSpace();
+        CancelDurableTask test = new CancelDurableTask();
+        test.runDurable(gs);
+    }
+
+    public void runDurable(GigaSpace gs) throws Exception{
+        UUID taskId = gs.registerDurableTask(new CancelableCountTask());
+        AsyncFuture<Long> future = gs.executeDurable(taskId);
+        future.setListener(result -> {
+            if (result.getException() != null) {
+                logger.error("Task failed", result.getException());
+            } else {
+                logger.info("Got results: {}", result.getResult());
+            }
+        });
+        Thread.sleep(WAIT_TIME);
+        gs.unregisterDurableTask(taskId);
+        // This task should be unregistered when we want to stop it or when it has ended.
+        // The only reason to register this task is to have the ability to stop it gracefully when we want.
+    }
+}

--- a/lab15-durable_task-example/durable/src/main/java/com/gs/CancelableCountTask.java
+++ b/lab15-durable_task-example/durable/src/main/java/com/gs/CancelableCountTask.java
@@ -1,0 +1,72 @@
+package com.gs;
+import com.gigaspaces.annotation.SupportCodeChange;
+import com.gigaspaces.async.AsyncResult;
+import com.gigaspaces.client.iterator.SpaceIterator;
+import com.j_spaces.core.client.SQLQuery;
+import org.openspaces.core.GigaSpace;
+import org.openspaces.core.executor.DurableTask;
+import org.openspaces.core.executor.TaskGigaSpace;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/*
+   This task iterates over all objects, does a time-consuming job, and returns the number of objects processed.
+ */
+
+@SupportCodeChange(id="1")
+public class CancelableCountTask implements  DurableTask<Integer, Long> {
+
+    private static final Logger logger = LoggerFactory.getLogger(CancelableCountTask.class);
+
+    @Override
+    public boolean isAutoStart() {
+        return false;
+    }
+
+    @TaskGigaSpace
+    private transient GigaSpace gigaSpace;
+
+    private transient volatile boolean cancel = false;
+
+
+    public Integer execute() throws Exception {
+        SQLQuery<Object> query = new SQLQuery<>(Object.class, "");
+        AtomicInteger counter = new AtomicInteger();
+        try (SpaceIterator<Object> spaceIterator = gigaSpace.iterator(query)) {
+            while (spaceIterator.hasNext() && !cancel) {
+                // spaceIterator.next();
+                logger.info("counting {}", counter.incrementAndGet());
+                Thread.sleep(500);
+            }
+        }
+        return counter.get();
+    }
+
+    public Long reduce(List<AsyncResult<Integer>> results) throws Exception {
+        long sum = 0;
+        for (AsyncResult<Integer> result : results) {
+            if (result.getException() != null) {
+                throw result.getException();
+            }
+            sum += result.getResult();
+        }
+        return sum;
+    }
+
+
+    public boolean cancel() throws Exception{
+        cancel = true;
+        return true;
+    }
+
+
+    public String name(){
+        return "CancelableCountTask";
+    }
+
+    public String description(){ return "Iterates over all entries in the partition, counting them with a simulated delay. Supports cancellation mid-run.";}
+}

--- a/lab15-durable_task-example/durable/src/main/java/com/gs/DataGen.java
+++ b/lab15-durable_task-example/durable/src/main/java/com/gs/DataGen.java
@@ -1,0 +1,58 @@
+package com.gs;
+
+
+import org.openspaces.core.GigaSpace;
+import org.openspaces.core.GigaSpaceConfigurer;
+import org.openspaces.core.space.SpaceProxyConfigurer;
+
+import java.sql.Date;
+import java.sql.SQLException;
+import java.util.ArrayList;
+
+
+public class DataGen {
+
+    public static void main(String[] args) throws SQLException {
+        GigaSpace gs = new GigaSpaceConfigurer(new SpaceProxyConfigurer("demo")).gigaSpace();
+        DataGen dataGenerator = new DataGen();
+        dataGenerator.writeData(gs);
+    }
+
+
+    public void writeData(GigaSpace gs){
+        ArrayList<Department> departments = new ArrayList<>(4);
+        departments.add(new Department(1, "toys"));
+        departments.add(new Department(2, "food"));
+        departments.add(new Department(3, "sport"));
+        departments.add(new Department(4, "kitchen-aid"));
+        departments.forEach(d->gs.write(d));
+        ArrayList<Product> products = new ArrayList<>(8);
+        products.add(new Product(1,"Train",11.1,1));
+        products.add(new Product(2,"Doll",17.8,1));
+        products.add(new Product(3,"Chocolate",10.0,2));
+        products.add(new Product(4,"Kandy",5.0,2));
+        products.add(new Product(5,"Basketball",150.0,3));
+        products.add(new Product(6,"Football",180.0,3));
+        products.add(new Product(7,"coffee-machine",999.0,4));
+        products.add(new Product(8,"Ice-maker",555.0,4));
+        products.forEach(p-> gs.write(p));
+        ArrayList<Customer> customers = new ArrayList<>(4);
+        customers.add(new Customer("Cohen","Avi", Date.valueOf("1980-02-01"),1));
+        customers.add(new Customer("Cohen","Sara", Date.valueOf("1984-03-05"),2));
+        customers.add(new Customer("Levi","Sara", Date.valueOf("1989-11-11"),3));
+        customers.add(new Customer("Levi","Moshe", Date.valueOf("2000-02-03"),4));
+        customers.forEach(c-> gs.write(c));
+        ArrayList<Purchase> purchese = new ArrayList<>(8);
+        purchese.add(new Purchase(1,1, 1));
+        purchese.add(new Purchase(2,2, 5));
+        purchese.add(new Purchase(3,3, 5));
+        purchese.add(new Purchase(4,4, 4));
+        purchese.add(new Purchase(5,2, 4));
+        purchese.add(new Purchase(6,2, 1));
+        purchese.add(new Purchase(7,3, 3));
+        purchese.add(new Purchase(8,1, 2));
+        purchese.forEach(p->gs.write(p))  ;
+    }
+
+
+}

--- a/lab15-durable_task-example/durable/src/main/java/com/gs/EmbeddedPollingDurableTask.java
+++ b/lab15-durable_task-example/durable/src/main/java/com/gs/EmbeddedPollingDurableTask.java
@@ -1,0 +1,71 @@
+package com.gs;
+
+import com.gigaspaces.annotation.SupportCodeChange;
+import com.gigaspaces.async.AsyncResult;
+import org.openspaces.core.GigaSpace;
+import org.openspaces.core.executor.DurableTask;
+import org.openspaces.core.executor.TaskGigaSpace;
+import org.openspaces.events.adapter.SpaceDataEvent;
+import org.openspaces.events.polling.SimplePollingContainerConfigurer;
+import org.openspaces.events.polling.SimplePollingEventListenerContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+@SupportCodeChange(id="1")
+public class EmbeddedPollingDurableTask implements DurableTask<Boolean, Boolean> {
+
+    private static final Logger logger = LoggerFactory.getLogger(EmbeddedPollingDurableTask.class);
+
+    @TaskGigaSpace
+        transient GigaSpace gigaSpace;
+        transient SimplePollingEventListenerContainer pollingEventListenerContainer;
+
+        @Override
+        public boolean isAutoStart()  {
+            return true;
+        }
+        @Override
+        public Boolean execute() throws Exception {
+            pollingEventListenerContainer = new SimplePollingContainerConfigurer(gigaSpace).template(new Purchase(PurchaseStatus.NEW))
+                    .autoStart(true).eventListenerAnnotation(new Object() {
+                        @SpaceDataEvent
+                        public void eventHappened(Purchase data) {
+                            try {
+                                data.setPurchaseStatus(PurchaseStatus.PROCESSED);
+                                logger.info("New event was Processed");
+                                //Do some logic
+                                Thread.sleep(100);
+                                // gigaSpace.write(data);
+                            } catch (InterruptedException e) {
+                                logger.error("Event processing interrupted", e);
+                                Thread.currentThread().interrupt();
+                            }
+                        }
+                    }).pollingContainer();
+            return true;
+        }
+        @Override
+        public Boolean reduce(List<AsyncResult<Boolean>> list) throws Exception {
+            for (AsyncResult<Boolean> result : list) {
+                if (result.getException() != null) {
+                    throw result.getException();
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public boolean cancel() throws Exception {
+            if (pollingEventListenerContainer != null) {
+                pollingEventListenerContainer.destroy();
+            }
+            return true;
+        }
+
+    public String name(){
+        return "Business Logic Task";
+    }
+
+    public String description(){ return "Runs an embedded polling container in each partition that processes unprocessed Purchase entries. Survives failover via auto-start.";}
+}

--- a/lab15-durable_task-example/durable/src/main/java/com/gs/RegisterDurableTask.java
+++ b/lab15-durable_task-example/durable/src/main/java/com/gs/RegisterDurableTask.java
@@ -1,0 +1,22 @@
+package com.gs;
+
+import org.openspaces.core.GigaSpace;
+import org.openspaces.core.GigaSpaceConfigurer;
+import org.openspaces.core.space.SpaceProxyConfigurer;
+
+import java.util.UUID;
+
+public class RegisterDurableTask {
+    public static void main(String[] args) {
+        GigaSpace gs = new GigaSpaceConfigurer(new SpaceProxyConfigurer("demo")).gigaSpace();
+        RegisterDurableTask test = new RegisterDurableTask();
+        test.runDurable(gs);
+    }
+
+    public void runDurable(GigaSpace gs) {
+        UUID taskId = gs.registerDurableTask(new EmbeddedPollingDurableTask());
+        System.out.println("Event task started embedded event container: " + taskId);
+        /* This task should be unregistered only if we want to change business logic.
+         * In that case we will unregister, change code, update supportcodechange version, and re-register. */
+    }
+}

--- a/lab15-durable_task-example/model/pom.xml
+++ b/lab15-durable_task-example/model/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.gigaspaces.dev.training</groupId>
+    <artifactId>model</artifactId>
+    <parent>
+        <artifactId>lab15-example</artifactId>
+        <groupId>com.gigaspaces.dev.training</groupId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+</project>

--- a/lab15-durable_task-example/model/src/main/java/com/gs/Customer.java
+++ b/lab15-durable_task-example/model/src/main/java/com/gs/Customer.java
@@ -1,0 +1,64 @@
+package com.gs;
+
+import com.gigaspaces.annotation.pojo.SpaceId;
+import com.gigaspaces.annotation.pojo.SpaceIndex;
+import com.gigaspaces.annotation.pojo.SpaceRouting;
+import com.gigaspaces.metadata.index.SpaceIndexType;
+
+import java.sql.Date;
+
+public class Customer {
+    String lastName;
+    String firsName;
+    Date birthday;
+    Integer id;
+
+    public Customer(String lastName, String firsName, Date birthday, Integer id) {
+        this.lastName = lastName;
+        this.firsName = firsName;
+        this.birthday = birthday;
+        this.id = id;
+    }
+
+    public Customer() {
+    }
+
+    @SpaceId
+    @SpaceRouting
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+
+    @SpaceIndex(type = SpaceIndexType.ORDERED)
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getFirsName() {
+        return firsName;
+    }
+
+    public void setFirsName(String firsName) {
+        this.firsName = firsName;
+    }
+
+
+
+
+    public Date getBirthday() {
+        return birthday;
+    }
+
+    public void setBirthday(Date birthday) {
+        this.birthday = birthday;
+    }
+}

--- a/lab15-durable_task-example/model/src/main/java/com/gs/Department.java
+++ b/lab15-durable_task-example/model/src/main/java/com/gs/Department.java
@@ -1,0 +1,35 @@
+package com.gs;
+
+import com.gigaspaces.annotation.pojo.SpaceClass;
+import com.gigaspaces.annotation.pojo.SpaceId;
+
+@SpaceClass(broadcast = true)
+public class Department {
+    Integer id;
+    String name;
+
+    public Department(Integer id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Department() {
+    }
+
+    @SpaceId
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/lab15-durable_task-example/model/src/main/java/com/gs/Product.java
+++ b/lab15-durable_task-example/model/src/main/java/com/gs/Product.java
@@ -1,0 +1,59 @@
+package com.gs;
+
+import com.gigaspaces.annotation.pojo.SpaceId;
+import com.gigaspaces.annotation.pojo.SpaceIndex;
+import com.gigaspaces.annotation.pojo.SpaceRouting;
+import com.gigaspaces.metadata.index.SpaceIndexType;
+
+public class Product {
+    Integer id;
+    String name;
+    Double price;
+    Integer depId;
+
+    public Product(Integer id, String name, Double price, Integer depId) {
+        this.id = id;
+        this.name = name;
+        this.price = price;
+        this.depId = depId;
+    }
+
+    public Product() {
+    }
+
+    @SpaceId
+    @SpaceRouting
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @SpaceIndex(type = SpaceIndexType.EQUAL_AND_ORDERED)
+    public Double getPrice() {
+        return price;
+    }
+
+
+    public void setPrice(Double price) {
+        this.price = price;
+    }
+
+    public Integer getDepId() {
+        return depId;
+    }
+
+    public void setDepId(Integer depId) {
+        this.depId = depId;
+    }
+}

--- a/lab15-durable_task-example/model/src/main/java/com/gs/Purchase.java
+++ b/lab15-durable_task-example/model/src/main/java/com/gs/Purchase.java
@@ -1,0 +1,76 @@
+package com.gs;
+
+import com.gigaspaces.annotation.pojo.SpaceClass;
+import com.gigaspaces.annotation.pojo.SpaceId;
+import com.gigaspaces.annotation.pojo.SpaceIndex;
+import com.gigaspaces.metadata.index.SpaceIndexType;
+
+
+@SpaceClass
+public class Purchase {
+    private String id;
+    private Integer amount;
+    private Integer customerId;
+    private Integer productId;
+    private PurchaseStatus purchaseStatus = PurchaseStatus.NEW;
+
+
+    public Purchase() {
+    }
+
+    public Purchase(Integer amount, Integer customerId, Integer productId) {
+        this.amount = amount;
+        this.customerId = customerId;
+        this.productId = productId;
+    }
+
+    public Purchase(PurchaseStatus purchaseStatus) {
+        this.purchaseStatus = purchaseStatus;
+    }
+
+    public PurchaseStatus getPurchaseStatus() {
+        return purchaseStatus;
+    }
+
+    public void setPurchaseStatus(PurchaseStatus purchaseStatus) {
+        this.purchaseStatus = purchaseStatus;
+    }
+
+    @SpaceId(autoGenerate = true)
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @SpaceIndex(type = SpaceIndexType.EQUAL_AND_ORDERED)
+    public Integer getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Integer amount) {
+        this.amount = amount;
+    }
+
+
+    public Integer getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(Integer customerId) {
+        this.customerId = customerId;
+    }
+
+
+    public Integer getProductId() {
+        return productId;
+    }
+
+    public void setProductId(Integer productId) {
+        this.productId = productId;
+    }
+
+
+}

--- a/lab15-durable_task-example/model/src/main/java/com/gs/PurchaseStatus.java
+++ b/lab15-durable_task-example/model/src/main/java/com/gs/PurchaseStatus.java
@@ -1,0 +1,5 @@
+package com.gs;
+
+public enum PurchaseStatus {
+    NEW, PROCESSED, FAILED;
+}

--- a/lab15-durable_task-example/pom.xml
+++ b/lab15-durable_task-example/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.gigaspaces.dev.training</groupId>
+    <artifactId>lab15-example</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <repositories>
+        <repository>
+            <id>org.openspaces</id>
+            <url>https://maven-repository.openspaces.org</url>
+        </repository>
+    </repositories>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <java.version>17</java.version>
+        <gigaspaces.version>17.2.1</gigaspaces.version>
+        <slf4j.version>2.0.11</slf4j.version>
+    </properties>
+    <modules>
+        <module>model</module>
+        <module>durable</module>
+        <module>space</module>
+    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>org.gigaspaces</groupId>
+            <artifactId>xap-openspaces</artifactId>
+            <version>${gigaspaces.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.gigaspaces</groupId>
+            <artifactId>xap-datagrid</artifactId>
+            <version>${gigaspaces.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/lab15-durable_task-example/runConfigurations/CancelDurableTask.xml
+++ b/lab15-durable_task-example/runConfigurations/CancelDurableTask.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="CancelDurableTask" type="Application" factoryName="Application">
+    <option name="ALTERNATIVE_JRE_PATH" value="17" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <option name="INCLUDE_PROVIDED_SCOPE" value="true" />
+    <option name="MAIN_CLASS_NAME" value="com.gs.CancelDurableTask" />
+    <module name="durable" />
+    <option name="VM_PARAMETERS" value="-Dcom.gs.jini_lus.locators=${GS_LOOKUP_LOCATORS} -Dcom.gs.jini_lus.groups=${GS_LOOKUP_GROUPS}" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/lab15-durable_task-example/runConfigurations/DataGen.xml
+++ b/lab15-durable_task-example/runConfigurations/DataGen.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="DataGen" type="Application" factoryName="Application">
+    <option name="ALTERNATIVE_JRE_PATH" value="17" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <option name="INCLUDE_PROVIDED_SCOPE" value="true" />
+    <option name="MAIN_CLASS_NAME" value="com.gs.DataGen" />
+    <module name="durable" />
+    <option name="VM_PARAMETERS" value="-Dcom.gs.jini_lus.locators=${GS_LOOKUP_LOCATORS} -Dcom.gs.jini_lus.groups=${GS_LOOKUP_GROUPS}" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/lab15-durable_task-example/runConfigurations/RegisterDurableTask.xml
+++ b/lab15-durable_task-example/runConfigurations/RegisterDurableTask.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="RegisterDurableTask" type="Application" factoryName="Application">
+    <option name="ALTERNATIVE_JRE_PATH" value="17" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <option name="INCLUDE_PROVIDED_SCOPE" value="true" />
+    <option name="MAIN_CLASS_NAME" value="com.gs.RegisterDurableTask" />
+    <module name="durable" />
+    <option name="VM_PARAMETERS" value="-Dcom.gs.jini_lus.locators=${GS_LOOKUP_LOCATORS} -Dcom.gs.jini_lus.groups=${GS_LOOKUP_GROUPS}" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/lab15-durable_task-example/space/pom.xml
+++ b/lab15-durable_task-example/space/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.gigaspaces.dev.training</groupId>
+    <artifactId>space</artifactId>
+    <name>space</name>
+    <parent>
+        <groupId>com.gigaspaces.dev.training</groupId>
+        <artifactId>lab15-example</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <dependencies>
+        <dependency>
+            <groupId>com.gigaspaces.dev.training</groupId>
+            <artifactId>model</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <finalName>space</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.7.1</version>
+                <configuration>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <attach>false</attach>
+                    <ignoreDirFormatExtensions>true</ignoreDirFormatExtensions>
+                    <descriptors>
+                        <descriptor>src/main/assembly/assembly.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/lab15-durable_task-example/space/src/main/assembly/assembly.xml
+++ b/lab15-durable_task-example/space/src/main/assembly/assembly.xml
@@ -1,0 +1,37 @@
+<assembly>
+  <id>assemble-pu</id>
+  <formats>
+    <format>jar</format>
+    <format>dir</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>target/classes</directory>
+      <lineEnding>keep</lineEnding>
+      <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>**/**</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+  <dependencySets>
+    <dependencySet>
+      <useProjectArtifact>false</useProjectArtifact>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <outputDirectory>lib</outputDirectory>
+      <excludes>
+        <exclude>com.gigaspaces.dev.training:model</exclude>
+      </excludes>
+    </dependencySet>
+    <dependencySet>
+      <useProjectArtifact>false</useProjectArtifact>
+      <useTransitiveDependencies>true</useTransitiveDependencies>
+      <useTransitiveFiltering>true</useTransitiveFiltering>
+      <outputDirectory>lib</outputDirectory>
+      <includes>
+        <include>com.gigaspaces.dev.training:model</include>
+      </includes>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/lab15-durable_task-example/space/src/main/resources/META-INF/spring/pu.xml
+++ b/lab15-durable_task-example/space/src/main/resources/META-INF/spring/pu.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:os-core="http://www.openspaces.org/schema/core"
+	xmlns:os-events="http://www.openspaces.org/schema/events"
+	xmlns:os-remoting="http://www.openspaces.org/schema/remoting"
+	xmlns:tx="http://www.springframework.org/schema/tx"
+
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+       http://www.openspaces.org/schema/core http://www.openspaces.org/schema/core/openspaces-core.xsd
+       http://www.openspaces.org/schema/events http://www.openspaces.org/schema/events/openspaces-events.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+       http://www.openspaces.org/schema/remoting http://www.openspaces.org/schema/remoting/openspaces-remoting.xsd">
+
+	<!-- ANNOTATION AND COMPONENT SCAN CONFIGURATION -->
+	<!-- Enable scan for OpenSpaces and Spring components -->
+	<context:component-scan base-package="com.gs" />
+
+	<!-- Enables the usage of @GigaSpaceContext annotation based injection. -->
+	<os-core:giga-space-context />
+	<!-- Enables Spring Annotation configuration -->
+	<context:annotation-config />
+	<!-- Enables using @Polling and @Notify annotations -->
+	<os-events:annotation-support />
+	<!-- Enables using @RemotingService as well as @ExecutorProxy (and others) 
+		annotations -->
+	<os-remoting:annotation-support />
+	<!-- Enables using @PreBackup, @PostBackup and other annotations -->
+	<os-core:annotation-support />
+	<!-- Transaction annotation support -->
+	<tx:annotation-driven transaction-manager="transactionManager" />
+	<!-- SPACE CONFIGURATION -->
+	<!-- A bean representing a space (an IJSpace implementation). -->
+	<os-core:embedded-space id="space" space-name="demo"/>
+	<!-- OpenSpaces simplified space API built on top of IJSpace/JavaSpace. -->
+	<os-core:giga-space id="gigaSpace" space="space"
+		tx-manager="transactionManager"/>
+
+	<!-- Defines a local Jini transaction manager. -->
+	<os-core:distributed-tx-manager id="transactionManager" />
+	<!-- Service exporter for exporting remote services -->
+	<os-remoting:service-exporter id="serviceExporter" />
+</beans>

--- a/lab15-durable_task-example/space/src/main/resources/META-INF/spring/sla.xml
+++ b/lab15-durable_task-example/space/src/main/resources/META-INF/spring/sla.xml
@@ -1,0 +1,14 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:os-sla="http://www.openspaces.org/schema/sla"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.openspaces.org/schema/sla
+	   http://www.openspaces.org/schema/sla/openspaces-sla.xsd">
+
+    <!-- The SLA bean used when deploying this processing unit to the Service Grid. -->
+    <os-sla:sla cluster-schema="partitioned"
+                number-of-instances="2" number-of-backups="1"
+                max-instances-per-vm="1">
+    </os-sla:sla>
+</beans>


### PR DESCRIPTION
 * Upgrade to 17.2.1.
 * Types are packaged with the space. Without this, the lab steps as written would cause a type descriptor mismatch.
 * Gave more descriptive names to durable tasks and their callers.
 * Edited the README.md.